### PR TITLE
Refactor header retrieval in `WorkerDebugModule`, `WorkerProfilingPanel`, and `WorkerTimelinePanel` to use `Request` instead of `Response` and update tests accordingly.

### DIFF
--- a/src/WorkerDebugModule.php
+++ b/src/WorkerDebugModule.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace yii2\extensions\debug;
 
+use Yii;
 use yii\debug\Module;
 use yii\helpers\Url;
 use yii\web\Response;
@@ -38,7 +39,7 @@ class WorkerDebugModule extends Module
         );
 
         if ($event->sender instanceof Response) {
-            $statelessAppStartTime = $event->sender->getHeaders()->get('statelessAppStartTime') ?? YII_BEGIN_TIME;
+            $statelessAppStartTime = Yii::$app->request->getHeaders()->get('statelessAppStartTime') ?? YII_BEGIN_TIME;
             $durationMs = ceil((microtime(true) - (float) $statelessAppStartTime) * 1000);
 
             $event->sender->getHeaders()

--- a/src/WorkerProfilingPanel.php
+++ b/src/WorkerProfilingPanel.php
@@ -15,7 +15,7 @@ class WorkerProfilingPanel extends ProfilingPanel
      */
     public function save(): array
     {
-        $statelessAppStartTime = Yii::$app->response->getHeaders()->get('statelessAppStartTime') ?? YII_BEGIN_TIME;
+        $statelessAppStartTime = Yii::$app->request->getHeaders()->get('statelessAppStartTime') ?? YII_BEGIN_TIME;
 
         return [
             'memory' => memory_get_peak_usage(),

--- a/src/WorkerTimelinePanel.php
+++ b/src/WorkerTimelinePanel.php
@@ -17,7 +17,7 @@ class WorkerTimelinePanel extends TimelinePanel
      */
     public function save(): array
     {
-        $statelessAppStartTime = Yii::$app->response->getHeaders()->get('statelessAppStartTime') ?? YII_BEGIN_TIME;
+        $statelessAppStartTime = Yii::$app->request->getHeaders()->get('statelessAppStartTime') ?? YII_BEGIN_TIME;
 
         return [
             'start' => (float) $statelessAppStartTime,

--- a/tests/WorkerDebugModuleTest.php
+++ b/tests/WorkerDebugModuleTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\Attributes\Group;
 use stdClass;
 use yii\base\Event;
 use yii\debug\LogTarget;
-use yii\web\{HeaderCollection, Response};
+use yii\web\{HeaderCollection, Request, Response};
 use yii2\extensions\debug\tests\support\stub\TimeFunctions;
 use yii2\extensions\debug\WorkerDebugModule;
 
@@ -83,7 +83,31 @@ final class WorkerDebugModuleTest extends TestCase
 
     public function testSetDebugHeadersCalculatesCorrectDurationInMilliseconds(): void
     {
-        $this->webApplication();
+        $startTime = '1234567890.500';
+        $currentTime = 1234567893.1234;
+
+        TimeFunctions::setMockedMicrotime($currentTime);
+
+        $headers = $this->createPartialMock(HeaderCollection::class, ['get', 'set']);
+
+        $headers->method('get')->with('statelessAppStartTime')->willReturn($startTime);
+
+        $request = $this->createPartialMock(Request::class, ['getHeaders']);
+
+        $request->method('getHeaders')->willReturn($headers);
+
+        $response = $this->createPartialMock(Response::class, ['getHeaders']);
+
+        $response->method('getHeaders')->willReturn($headers);
+
+        $this->webApplication(
+            [
+                'components' => [
+                    'request' => $request,
+                    'response' => $response,
+                ],
+            ],
+        );
 
         $module = $this->createPartialMock(
             WorkerDebugModule::class,
@@ -100,15 +124,6 @@ final class WorkerDebugModuleTest extends TestCase
 
         $logTarget->tag = 'test-debug-tag';
         $module->logTarget = $logTarget;
-
-        $startTime = '1234567890.500';
-        $currentTime = 1234567893.1234;
-
-        TimeFunctions::setMockedMicrotime($currentTime);
-
-        $headers = $this->createMock(HeaderCollection::class);
-
-        $headers->method('get')->with('statelessAppStartTime')->willReturn($startTime);
 
         $durationCaptured = false;
 
@@ -131,10 +146,6 @@ final class WorkerDebugModuleTest extends TestCase
                 },
             );
 
-        $response = $this->createMock(Response::class);
-
-        $response->method('getHeaders')->willReturn($headers);
-
         $event = new Event();
 
         $event->sender = $response;
@@ -149,15 +160,21 @@ final class WorkerDebugModuleTest extends TestCase
 
     public function testSetDebugHeadersDoesNothingWhenAccessIsNotAllowed(): void
     {
-        $this->webApplication();
+        $response = $this->createPartialMock(Response::class, ['getHeaders']);
+
+        $response->expects(self::never())->method('getHeaders');
+
+        $this->webApplication(
+            [
+                'components' => [
+                    'response' => $response,
+                ],
+            ],
+        );
 
         $module = $this->createPartialMock(WorkerDebugModule::class, ['checkAccess']);
 
         $module->method('checkAccess')->willReturn(false);
-
-        $response = $this->createMock(Response::class);
-
-        $response->expects(self::never())->method('getHeaders');
 
         $logTarget = $this->createMock(LogTarget::class);
 
@@ -173,17 +190,23 @@ final class WorkerDebugModuleTest extends TestCase
 
     public function testSetDebugHeadersDoesNothingWhenLogTargetIsArray(): void
     {
-        $this->webApplication();
+        $response = $this->createPartialMock(Response::class, ['getHeaders']);
+
+        $response->expects(self::never())->method('getHeaders');
+
+        $this->webApplication(
+            [
+                'components' => [
+                    'response' => $response,
+                ],
+            ],
+        );
 
         $module = $this->createPartialMock(WorkerDebugModule::class, ['checkAccess']);
 
         $module->method('checkAccess')->willReturn(true);
 
         $module->logTarget = ['array-target'];
-
-        $response = $this->createMock(Response::class);
-
-        $response->expects(self::never())->method('getHeaders');
 
         $event = new Event();
 
@@ -194,17 +217,23 @@ final class WorkerDebugModuleTest extends TestCase
 
     public function testSetDebugHeadersDoesNothingWhenLogTargetIsString(): void
     {
-        $this->webApplication();
+        $response = $this->createPartialMock(Response::class, ['getHeaders']);
+
+        $response->expects(self::never())->method('getHeaders');
+
+        $this->webApplication(
+            [
+                'components' => [
+                    'response' => $response,
+                ],
+            ],
+        );
 
         $module = $this->createPartialMock(WorkerDebugModule::class, ['checkAccess']);
 
         $module->method('checkAccess')->willReturn(true);
 
         $module->logTarget = 'string-target';
-
-        $response = $this->createMock(Response::class);
-
-        $response->expects(self::never())->method('getHeaders');
 
         $event = new Event();
 
@@ -235,9 +264,30 @@ final class WorkerDebugModuleTest extends TestCase
         $module->setDebugHeaders($event);
     }
 
-    public function testSetDebugHeadersSetsCorrectHeadersWhenConditionsAreMet(): void
+    public function testSetDebugHeadersUsesStatelessAppStartTimeWhenAvailable(): void
     {
-        $this->webApplication();
+        $customStartTime = (string) (microtime(true) - 1);
+
+        $headers = $this->createMock(HeaderCollection::class);
+
+        $headers->method('get')->with('statelessAppStartTime')->willReturn($customStartTime);
+
+        $request = $this->createPartialMock(Request::class, ['getHeaders']);
+
+        $request->method('getHeaders')->willReturn($headers);
+
+        $response = $this->createPartialMock(Response::class, ['getHeaders']);
+
+        $response->method('getHeaders')->willReturn($headers);
+
+        $this->webApplication(
+            [
+                'components' => [
+                    'request' => $request,
+                    'response' => $response,
+                ],
+            ],
+        );
 
         $module = $this->createPartialMock(
             WorkerDebugModule::class,
@@ -255,9 +305,79 @@ final class WorkerDebugModuleTest extends TestCase
         $logTarget->tag = 'test-debug-tag';
         $module->logTarget = $logTarget;
 
+        $durationCaptured = false;
+
+        $headers
+            ->expects(self::exactly(3))
+            ->method('set')
+            ->willReturnCallback(
+                static function (string $name, string $value) use ($headers, &$durationCaptured): HeaderCollection {
+                    if ($name === 'X-Debug-Duration') {
+                        self::assertGreaterThan(
+                            0,
+                            (float) $value,
+                            "'X-Debug-Duration' header should be greater than '0' when 'statelessAppStartTime' is " .
+                            "available, got: {$value}.",
+                        );
+                        self::assertLessThan(
+                            10000,
+                            (float) $value,
+                            "'X-Debug-Duration' should be a reasonable duration in milliseconds, got: {$value}. " .
+                            'This suggests incorrect calculation (possibly addition instead of subtraction).',
+                        );
+
+                        $durationCaptured = true;
+                    }
+
+                    return $headers;
+                },
+            );
+
+        $event = new Event();
+
+        $event->sender = $response;
+
+        $module->setDebugHeaders($event);
+
+        self::assertTrue(
+            $durationCaptured,
+            "'X-Debug-Duration' header should be set when 'statelessAppStartTime' is available.",
+        );
+    }
+
+    public function testSetDebugHeadersUsesYiiBeginTimeWhenStatelessAppStartTimeHeaderIsMissing(): void
+    {
         $headers = $this->createMock(HeaderCollection::class);
 
         $headers->method('get')->with('statelessAppStartTime')->willReturn(null);
+
+        $response = $this->createPartialMock(Response::class, ['getHeaders']);
+
+        $response->method('getHeaders')->willReturn($headers);
+
+        $this->webApplication(
+            [
+                'components' => [
+                    'response' => $response,
+                ],
+            ],
+        );
+
+        $module = $this->createPartialMock(
+            WorkerDebugModule::class,
+            [
+                'checkAccess',
+                'getUniqueId',
+            ],
+        );
+
+        $module->method('checkAccess')->willReturn(true);
+        $module->method('getUniqueId')->willReturn('test-module');
+
+        $logTarget = $this->createMock(LogTarget::class);
+
+        $logTarget->tag = 'test-debug-tag';
+        $module->logTarget = $logTarget;
 
         $callCount = 0;
 
@@ -309,84 +429,10 @@ final class WorkerDebugModuleTest extends TestCase
                 },
             );
 
-        $response = $this->createMock(Response::class);
-
-        $response->method('getHeaders')->willReturn($headers);
-
         $event = new Event();
 
         $event->sender = $response;
 
         $module->setDebugHeaders($event);
-    }
-
-    public function testSetDebugHeadersUsesStatelessAppStartTimeWhenAvailable(): void
-    {
-        $this->webApplication();
-
-        $module = $this->createPartialMock(
-            WorkerDebugModule::class,
-            [
-                'checkAccess',
-                'getUniqueId',
-            ],
-        );
-
-        $module->method('checkAccess')->willReturn(true);
-        $module->method('getUniqueId')->willReturn('test-module');
-
-        $logTarget = $this->createMock(LogTarget::class);
-
-        $logTarget->tag = 'test-debug-tag';
-        $module->logTarget = $logTarget;
-
-        $customStartTime = (string) (microtime(true) - 1);
-
-        $headers = $this->createMock(HeaderCollection::class);
-
-        $headers->method('get')->with('statelessAppStartTime')->willReturn($customStartTime);
-
-        $durationCaptured = false;
-
-        $headers
-            ->expects(self::exactly(3))
-            ->method('set')
-            ->willReturnCallback(
-                static function (string $name, string $value) use ($headers, &$durationCaptured): HeaderCollection {
-                    if ($name === 'X-Debug-Duration') {
-                        self::assertGreaterThan(
-                            0,
-                            (float) $value,
-                            "'X-Debug-Duration' header should be greater than '0' when 'statelessAppStartTime' is " .
-                            "available, got: {$value}.",
-                        );
-                        self::assertLessThan(
-                            10000,
-                            (float) $value,
-                            "'X-Debug-Duration' should be a reasonable duration in milliseconds, got: {$value}. " .
-                            'This suggests incorrect calculation (possibly addition instead of subtraction).',
-                        );
-
-                        $durationCaptured = true;
-                    }
-
-                    return $headers;
-                },
-            );
-
-        $response = $this->createMock(Response::class);
-
-        $response->method('getHeaders')->willReturn($headers);
-
-        $event = new Event();
-
-        $event->sender = $response;
-
-        $module->setDebugHeaders($event);
-
-        self::assertTrue(
-            $durationCaptured,
-            "'X-Debug-Duration' header should be set when 'statelessAppStartTime' is available.",
-        );
     }
 }

--- a/tests/WorkerProfilingPanelTest.php
+++ b/tests/WorkerProfilingPanelTest.php
@@ -6,7 +6,7 @@ namespace yii2\extensions\debug\tests;
 
 use PHPUnit\Framework\Attributes\Group;
 use yii\log\Logger;
-use yii\web\{HeaderCollection, Response};
+use yii\web\{HeaderCollection, Request};
 use yii2\extensions\debug\WorkerProfilingPanel;
 
 #[Group('worker-debug')]
@@ -16,18 +16,18 @@ final class WorkerProfilingPanelTest extends TestCase
     {
         $customStartTime = (string) (microtime(true) - 2);
 
-        $headers = $this->createMock(HeaderCollection::class);
+        $headers = $this->createPartialMock(HeaderCollection::class, ['get']);
 
         $headers->method('get')->with('statelessAppStartTime')->willReturn($customStartTime);
 
-        $response = $this->createMock(Response::class);
+        $request = $this->createPartialMock(Request::class, ['getHeaders']);
 
-        $response->method('getHeaders')->willReturn($headers);
+        $request->method('getHeaders')->willReturn($headers);
 
         $this->webApplication(
             [
                 'components' => [
-                    'response' => $response,
+                    'request' => $request,
                 ],
             ],
         );
@@ -64,18 +64,18 @@ final class WorkerProfilingPanelTest extends TestCase
 
     public function testSaveReturnsCorrectDataStructureWithDefaultStartTime(): void
     {
-        $headers = $this->createMock(HeaderCollection::class);
+        $headers = $this->createPartialMock(HeaderCollection::class, ['get']);
 
         $headers->method('get')->with('statelessAppStartTime')->willReturn(null);
 
-        $response = $this->createMock(Response::class);
+        $request = $this->createPartialMock(Request::class, ['getHeaders']);
 
-        $response->method('getHeaders')->willReturn($headers);
+        $request->method('getHeaders')->willReturn($headers);
 
         $this->webApplication(
             [
                 'components' => [
-                    'response' => $response,
+                    'request' => $request,
                 ],
             ],
         );
@@ -125,18 +125,18 @@ final class WorkerProfilingPanelTest extends TestCase
 
     public function testSaveUsesMemoryGetPeakUsage(): void
     {
-        $headers = $this->createMock(HeaderCollection::class);
+        $headers = $this->createPartialMock(HeaderCollection::class, ['get']);
 
         $headers->method('get')->with('statelessAppStartTime')->willReturn(null);
 
-        $response = $this->createMock(Response::class);
+        $request = $this->createPartialMock(Request::class, ['getHeaders']);
 
-        $response->method('getHeaders')->willReturn($headers);
+        $request->method('getHeaders')->willReturn($headers);
 
         $this->webApplication(
             [
                 'components' => [
-                    'response' => $response,
+                    'request' => $request,
                 ],
             ],
         );

--- a/tests/WorkerTimelinePanelTest.php
+++ b/tests/WorkerTimelinePanelTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace yii2\extensions\debug\tests;
 
 use PHPUnit\Framework\Attributes\Group;
-use yii\web\{HeaderCollection, Response};
+use yii\web\{HeaderCollection, Request};
 use yii2\extensions\debug\WorkerTimelinePanel;
 
 #[Group('worker-debug')]
@@ -15,18 +15,18 @@ final class WorkerTimelinePanelTest extends TestCase
     {
         $customStartTime = (string) (microtime(true) - 2);
 
-        $headers = $this->createMock(HeaderCollection::class);
+        $headers = $this->createPartialMock(HeaderCollection::class, ['get']);
 
         $headers->method('get')->with('statelessAppStartTime')->willReturn($customStartTime);
 
-        $response = $this->createMock(Response::class);
+        $request = $this->createPartialMock(Request::class, ['getHeaders']);
 
-        $response->method('getHeaders')->willReturn($headers);
+        $request->method('getHeaders')->willReturn($headers);
 
         $this->webApplication(
             [
                 'components' => [
-                    'response' => $response,
+                    'request' => $request,
                 ],
             ],
         );
@@ -62,18 +62,18 @@ final class WorkerTimelinePanelTest extends TestCase
 
     public function testSaveReturnsCorrectDataStructureWithDefaultStartTime(): void
     {
-        $headers = $this->createMock(HeaderCollection::class);
+        $headers = $this->createPartialMock(HeaderCollection::class, ['get']);
 
         $headers->method('get')->with('statelessAppStartTime')->willReturn(null);
 
-        $response = $this->createMock(Response::class);
+        $request = $this->createPartialMock(Request::class, ['getHeaders']);
 
-        $response->method('getHeaders')->willReturn($headers);
+        $request->method('getHeaders')->willReturn($headers);
 
         $this->webApplication(
             [
                 'components' => [
-                    'response' => $response,
+                    'request' => $request,
                 ],
             ],
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
