### PR TITLE
Replace `TimeFunctions` with `MockerFunctions` in test cases and introduce `MockerFunctions` for mocking microtime behavior.

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,7 +7,7 @@ namespace yii2\extensions\debug\tests;
 use Yii;
 use yii\helpers\ArrayHelper;
 use yii\web\{Application, HeaderCollection, Request};
-use yii2\extensions\debug\tests\support\stub\TimeFunctions;
+use yii2\extensions\debug\tests\support\stub\MockerFunctions;
 
 abstract class TestCase extends \PHPUnit\Framework\TestCase
 {
@@ -20,7 +20,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
     {
         $this->closeApplication();
 
-        TimeFunctions::clearMockedMicrotime();
+        MockerFunctions::clearMockedMicrotime();
 
         parent::tearDown();
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -16,11 +16,16 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
      */
     protected const COOKIE_VALIDATION_KEY = 'wefJDF8sfdsfSDefwqdxj9oq'; // gitleaks:allow (test-only, not a real secret)
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        MockerFunctions::clearMockedMicrotime();
+    }
+
     public function tearDown(): void
     {
         $this->closeApplication();
-
-        MockerFunctions::clearMockedMicrotime();
 
         parent::tearDown();
     }

--- a/tests/WorkerDebugModuleTest.php
+++ b/tests/WorkerDebugModuleTest.php
@@ -10,7 +10,7 @@ use stdClass;
 use yii\base\Event;
 use yii\debug\LogTarget;
 use yii\web\{HeaderCollection, Response};
-use yii2\extensions\debug\tests\support\stub\TimeFunctions;
+use yii2\extensions\debug\tests\support\stub\MockerFunctions;
 use yii2\extensions\debug\WorkerDebugModule;
 
 #[Group('worker-debug')]
@@ -86,7 +86,7 @@ final class WorkerDebugModuleTest extends TestCase
         $startTime = '1234567890.500';
         $currentTime = 1234567893.1234;
 
-        TimeFunctions::setMockedMicrotime($currentTime);
+        MockerFunctions::setMockedMicrotime($currentTime);
 
         $headers = $this->createPartialMock(HeaderCollection::class, ['get', 'set']);
 

--- a/tests/support/MockerExtension.php
+++ b/tests/support/MockerExtension.php
@@ -9,7 +9,7 @@ use PHPUnit\Event\TestSuite\{Started, StartedSubscriber};
 use PHPUnit\Runner\Extension\{Extension, Facade, ParameterCollection};
 use PHPUnit\TextUI\Configuration\Configuration;
 use Xepozz\InternalMocker\{Mocker, MockerState};
-use yii2\extensions\debug\tests\support\stub\TimeFunctions;
+use yii2\extensions\debug\tests\support\stub\MockerFunctions;
 
 final class MockerExtension implements Extension
 {
@@ -37,7 +37,7 @@ final class MockerExtension implements Extension
             [
                 'namespace' => 'yii2\extensions\debug',
                 'name' => 'microtime',
-                'function' => static fn(bool $as_float = false): float|string => TimeFunctions::microtime($as_float),
+                'function' => static fn(bool $as_float = false): float|string => MockerFunctions::microtime($as_float),
             ],
         ];
 

--- a/tests/support/stub/MockerFunctions.php
+++ b/tests/support/stub/MockerFunctions.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace yii2\extensions\debug\tests\support\stub;
 
-final class TimeFunctions
+final class MockerFunctions
 {
     private static float|null $mockedMicrotime = null;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
