### PR TITLE
fix: Update branch alias version in `composer.json` from `0.1.x-dev` to `0.2.x-dev`.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "0.1.x-dev"
+            "dev-main": "0.2.x-dev"
         }
     },
     "config": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development branch version alias from 0.1.x-dev to 0.2.x-dev to align package metadata and dependency resolution.
  * Affects only how development builds are labeled and consumed via package managers.
  * No functional changes, APIs, or configuration updates; runtime behavior remains unchanged.
  * No action required for users; future development snapshots will identify as 0.2.x-dev.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->