### PR TITLE
fix: Exclude `phpstan-console.neon` from the package in `.gitattributes`.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -36,6 +36,7 @@
 /docs                           export-ignore
 /ecs.php                        export-ignore
 /infection.json5                export-ignore
+/phpstan-console.neon           export-ignore
 /phpstan.neon                   export-ignore
 /phpunit.xml.dist               export-ignore
 /psalm.xml                      export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -36,8 +36,7 @@
 /docs                           export-ignore
 /ecs.php                        export-ignore
 /infection.json5                export-ignore
-/phpstan-console.neon           export-ignore
-/phpstan.neon                   export-ignore
+/phpstan*.neon                  export-ignore
 /phpunit.xml.dist               export-ignore
 /psalm.xml                      export-ignore
 /rector.php                     export-ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.1.1 Under development
 
 Bug #8: Add comprehensive PHPDoc for all classes (@terabytesoftw)
+Bug #9: Exclude `phpstan-console.neon` from the package in `.gitattributes` (@terabytesoftw)
 
 ## 0.1.0 August 16, 2024
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Excluded an internal development configuration from packaged distributions to keep installs cleaner and reduce unnecessary artifacts. No runtime or API impact.

* **Documentation**
  * Updated the changelog (v0.1.1) to record the packaging adjustment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->