### PR TITLE
fix: Update `php-forge/support` version to `^0.2` in `composer.json`, refactor test method invocation in `WorkerDebugModuleTest.php` class.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Bug #8: Add comprehensive PHPDoc for all classes (@terabytesoftw)
 - Bug #9: Exclude `phpstan-console.neon` from the package in `.gitattributes` (@terabytesoftw)
 - Bug #10: Update workflow actions to use `v1` stable version instead of `main`, update `LICENSE.md` (@terabytesoftw)
+- Bug #11: Update `php-forge/support` version to `^0.2` in `composer.json`, refactor test method invocation in `WorkerDebugModuleTest.php` class (@terabytesoftw)
 
 ## 0.1.0 August 16, 2025
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require-dev": {
         "infection/infection": "^0.27|^0.31",
         "maglnet/composer-require-checker": "^4.1",
-        "php-forge/support": "^0.1",
+        "php-forge/support": "^0.2",
         "phpstan/extension-installer": "^1.4",
         "phpstan/phpstan-strict-rules": "^2.0.3",
         "phpunit/phpunit": "^10.5",

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace yii2\extensions\debug\tests;
 
+use PHPForge\Support\TestSupport;
 use PHPUnit\Framework\MockObject\Exception;
 use Yii;
 use yii\base\InvalidConfigException;
@@ -33,6 +34,8 @@ use function dirname;
  */
 abstract class TestCase extends \PHPUnit\Framework\TestCase
 {
+    use TestSupport;
+
     /**
      * A secret key used for cookie validation in tests.
      */

--- a/tests/WorkerDebugModuleTest.php
+++ b/tests/WorkerDebugModuleTest.php
@@ -72,7 +72,7 @@ final class WorkerDebugModuleTest extends TestCase
             'the expected path.',
         );
 
-        $panels = Assert::invokeMethod($module, 'corePanels');
+        $panels = self::invokeMethod($module, 'corePanels');
 
         self::assertSame(
             [

--- a/tests/WorkerDebugModuleTest.php
+++ b/tests/WorkerDebugModuleTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace yii2\extensions\debug\tests;
 
-use PHPForge\Support\Assert;
 use PHPUnit\Framework\Attributes\Group;
 use stdClass;
 use yii\base\{Event, InvalidConfigException};


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added changelog entry for Bug #11 under version 0.1.1 (August 17, 2025).
* **Chores**
  * Updated development dependency to php-forge/support ^0.2 to align with latest tooling.
* **Tests**
  * Adopted improved test support utilities and streamlined method invocation in tests.
  * No changes to app behavior; updates are limited to test infrastructure and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->