### PR TITLE
fix: Read `REQUEST_TIME_FLOAT` from request server params instead of headers across worker debug panels and module.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 - Bug #23: Add `Super-Linter` badge to `README.md` for improved visibility on code quality checks (@terabytesoftw)
 - Bug #24: Replace `MockerFunctions` with `MockerState` class for `microtime()` handling and improve test isolation (@terabytesoftw)
-- Bug #25: Standardize PHPUnit PHPDoc headers across `src` and `tests`, replace `statelessAppStartTime` header with `REQUEST_TIME_FLOAT` (with `YII_BEGIN_TIME` fallback) for timing measurements (@terabytesoftw)
+- Bug #25: Standardize PHPUnit PHPDoc headers across `src` and `tests`, replace `statelessAppStartTime` with `REQUEST_TIME_FLOAT` (with `YII_BEGIN_TIME` fallback) for timing measurements (@terabytesoftw)
+- Bug #26: Read `REQUEST_TIME_FLOAT` from request server params instead of headers across worker debug panels and module (@terabytesoftw)
 
 ## 0.1.2 January 27, 2026
 

--- a/src/WorkerDebugModule.php
+++ b/src/WorkerDebugModule.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace yii2\extensions\debug;
 
-use Yii;
 use yii\base\{Event, InvalidConfigException};
 use yii\debug\Module;
 use yii\helpers\Url;
@@ -16,7 +15,7 @@ use function is_array;
 use function is_string;
 
 /**
- * Extends Yii debug module integration for worker profiling and timeline panels.
+ * Integrates Yii debug module panels for worker mode and emits debug headers with worker-safe timing.
  *
  * @copyright Copyright (C) 2025 Terabytesoftw.
  * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
@@ -36,7 +35,9 @@ class WorkerDebugModule extends Module
     }
 
     /**
-     * Sets debug headers for the current response when access is allowed.
+     * Sets debug headers when access is allowed and the sender is a response.
+     *
+     * Reads request start time from $_SERVER['REQUEST_TIME_FLOAT'] and falls back to YII_BEGIN_TIME.
      *
      * @param Event $event Event object containing the response sender.
      */
@@ -57,7 +58,7 @@ class WorkerDebugModule extends Module
                     'tag' => $this->logTarget->tag,
                 ],
             );
-            $requestTimeFloat = Yii::$app->request->getHeaders()->get('REQUEST_TIME_FLOAT') ?? YII_BEGIN_TIME;
+            $requestTimeFloat = $_SERVER['REQUEST_TIME_FLOAT'] ?? YII_BEGIN_TIME;
             $durationMs = ceil((microtime(true) - (float) $requestTimeFloat) * 1000);
 
             $event->sender->getHeaders()

--- a/src/WorkerDebugModule.php
+++ b/src/WorkerDebugModule.php
@@ -58,8 +58,9 @@ class WorkerDebugModule extends Module
                     'tag' => $this->logTarget->tag,
                 ],
             );
+            /** @phpstan-var float $requestTimeFloat */
             $requestTimeFloat = $_SERVER['REQUEST_TIME_FLOAT'] ?? YII_BEGIN_TIME;
-            $durationMs = ceil((microtime(true) - (float) $requestTimeFloat) * 1000);
+            $durationMs = ceil((microtime(true) - $requestTimeFloat) * 1000);
 
             $event->sender->getHeaders()
                 ->set('X-Debug-Tag', $this->logTarget->tag)

--- a/src/WorkerProfilingPanel.php
+++ b/src/WorkerProfilingPanel.php
@@ -28,11 +28,12 @@ class WorkerProfilingPanel extends ProfilingPanel
      */
     public function save(): array
     {
+        /** @phpstan-var float $requestTimeFloat */
         $requestTimeFloat = $_SERVER['REQUEST_TIME_FLOAT'] ?? YII_BEGIN_TIME;
 
         return [
             'memory' => memory_get_peak_usage(),
-            'time' => microtime(true) - (float) $requestTimeFloat,
+            'time' => microtime(true) - $requestTimeFloat,
             'messages' => $this->getLogMessages(Logger::LEVEL_PROFILE),
         ];
     }

--- a/src/WorkerProfilingPanel.php
+++ b/src/WorkerProfilingPanel.php
@@ -4,14 +4,13 @@ declare(strict_types=1);
 
 namespace yii2\extensions\debug;
 
-use Yii;
 use yii\debug\panels\ProfilingPanel;
 use yii\log\Logger;
 
 use function memory_get_peak_usage;
 
 /**
- * Extends Yii profiling panel behavior for stateless worker requests.
+ * Provides profiling panel data with worker-safe request timing.
  *
  * @copyright Copyright (C) 2025 Terabytesoftw.
  * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
@@ -21,13 +20,15 @@ class WorkerProfilingPanel extends ProfilingPanel
     /**
      * Saves profiling data for memory usage, execution time, and profile messages.
      *
+     * Reads request start time from $_SERVER['REQUEST_TIME_FLOAT'] and falls back to YII_BEGIN_TIME.
+     *
      * @return array Profiling data.
      *
      * @phpstan-return array<array-key, mixed>
      */
     public function save(): array
     {
-        $requestTimeFloat = Yii::$app->request->getHeaders()->get('REQUEST_TIME_FLOAT') ?? YII_BEGIN_TIME;
+        $requestTimeFloat = $_SERVER['REQUEST_TIME_FLOAT'] ?? YII_BEGIN_TIME;
 
         return [
             'memory' => memory_get_peak_usage(),

--- a/src/WorkerTimelinePanel.php
+++ b/src/WorkerTimelinePanel.php
@@ -4,13 +4,12 @@ declare(strict_types=1);
 
 namespace yii2\extensions\debug;
 
-use Yii;
 use yii\debug\panels\TimelinePanel;
 
 use function memory_get_peak_usage;
 
 /**
- * Extends Yii timeline panel behavior for stateless worker requests.
+ * Provides timeline panel data with worker-safe request timing.
  *
  * @copyright Copyright (C) 2025 Terabytesoftw.
  * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
@@ -20,13 +19,15 @@ class WorkerTimelinePanel extends TimelinePanel
     /**
      * Saves timeline data for request start, request end, and peak memory usage.
      *
+     * Reads request start time from $_SERVER['REQUEST_TIME_FLOAT'] and falls back to YII_BEGIN_TIME.
+     *
      * @return array Timeline data.
      *
      * @phpstan-return array<array-key, mixed>
      */
     public function save(): array
     {
-        $requestTimeFloat = Yii::$app->request->getHeaders()->get('REQUEST_TIME_FLOAT') ?? YII_BEGIN_TIME;
+        $requestTimeFloat = $_SERVER['REQUEST_TIME_FLOAT'] ?? YII_BEGIN_TIME;
 
         return [
             'start' => (float) $requestTimeFloat,

--- a/src/WorkerTimelinePanel.php
+++ b/src/WorkerTimelinePanel.php
@@ -30,7 +30,7 @@ class WorkerTimelinePanel extends TimelinePanel
         $requestTimeFloat = $_SERVER['REQUEST_TIME_FLOAT'] ?? YII_BEGIN_TIME;
 
         return [
-            'start' => (float) $requestTimeFloat,
+            'start' => $requestTimeFloat,
             'end' => microtime(true),
             'memory' => memory_get_peak_usage(),
         ];

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -56,17 +56,16 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * Creates a partial {@see Request} instance with the 'REQUEST_TIME_FLOAT' server param mocked.
+     * Creates a {@see Request} instance with the $_SERVER['REQUEST_TIME_FLOAT'] server param set or unset.
      *
-     * Builds a web request object with the 'REQUEST_TIME_FLOAT' server param set to the provided value, enabling
-     * tests for
+     * Builds a web request object with the REQUEST_TIME_FLOAT server param set to the provided value, or unset when
      * stateless application scenarios and start time measurement.
      *
-     * @param string|null $value Value to return for the 'REQUEST_TIME_FLOAT' server param.
+     * @param float|null $value Value to return for the REQUEST_TIME_FLOAT server param.
      *
      * @return Request Request instance with prepared server params.
      */
-    protected function buildRequestWithStatelessStart(string|null $value): Request
+    protected function buildRequestWithStatelessStart(float|null $value): Request
     {
         $this->hasOriginalRequestTimeFloat = array_key_exists('REQUEST_TIME_FLOAT', $_SERVER);
         $this->originalRequestTimeFloat = $_SERVER['REQUEST_TIME_FLOAT'] ?? null;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,11 +4,10 @@ declare(strict_types=1);
 
 namespace yii2\extensions\debug\tests;
 
-use PHPUnit\Framework\MockObject\Exception;
 use Yii;
 use yii\base\InvalidConfigException;
 use yii\helpers\ArrayHelper;
-use yii\web\{Application, HeaderCollection, IdentityInterface, Request};
+use yii\web\{Application, IdentityInterface, Request};
 
 use function dirname;
 
@@ -29,40 +28,62 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
     protected const COOKIE_VALIDATION_KEY = 'wefJDF8sfdsfSDefwqdxj9oq'; // gitleaks:allow (test-only, not a real secret)
 
     /**
+     * Tracks whether the original REQUEST_TIME_FLOAT value existed before test override.
+     */
+    private bool $hasOriginalRequestTimeFloat = false;
+
+    /**
+     * Stores the original REQUEST_TIME_FLOAT value for restoration in tearDown.
+     */
+    private mixed $originalRequestTimeFloat = null;
+
+    /**
      * Tears down the test environment after each test execution.
      *
      * Closes the application and flushes the logger to ensure a clean state for subsequent tests.
      */
     public function tearDown(): void
     {
+        if ($this->hasOriginalRequestTimeFloat) {
+            $_SERVER['REQUEST_TIME_FLOAT'] = $this->originalRequestTimeFloat;
+        } else {
+            unset($_SERVER['REQUEST_TIME_FLOAT']);
+        }
+
         $this->closeApplication();
 
         parent::tearDown();
     }
 
     /**
-     * Creates a partial {@see Request} instance with the 'REQUEST_TIME_FLOAT' header mocked.
+     * Creates a partial {@see Request} instance with the 'REQUEST_TIME_FLOAT' server param mocked.
      *
-     * Builds a web request object with the 'REQUEST_TIME_FLOAT' header set to the provided value, enabling tests for
+     * Builds a web request object with the 'REQUEST_TIME_FLOAT' server param set to the provided value, enabling
+     * tests for
      * stateless application scenarios and start time measurement.
      *
-     * @param string|null $value Value to return for the 'REQUEST_TIME_FLOAT' header.
+     * @param string|null $value Value to return for the 'REQUEST_TIME_FLOAT' server param.
      *
-     * @throws Exception If the mock object creation fails.
-     *
-     * @return Request Partial request instance with the mocked header.
+     * @return Request Request instance with prepared server params.
      */
     protected function buildRequestWithStatelessStart(string|null $value): Request
     {
-        $headers = $this->createPartialMock(HeaderCollection::class, ['get']);
+        $this->hasOriginalRequestTimeFloat = array_key_exists('REQUEST_TIME_FLOAT', $_SERVER);
+        $this->originalRequestTimeFloat = $_SERVER['REQUEST_TIME_FLOAT'] ?? null;
 
-        $headers->method('get')->with('REQUEST_TIME_FLOAT')->willReturn($value);
+        if ($value === null) {
+            unset($_SERVER['REQUEST_TIME_FLOAT']);
+        } else {
+            $_SERVER['REQUEST_TIME_FLOAT'] = $value;
+        }
 
-        $request = $this->createPartialMock(Request::class, ['getHeaders']);
-
-        $request->method('getHeaders')->willReturn($headers);
-
-        return $request;
+        return new Request(
+            [
+                'cookieValidationKey' => self::COOKIE_VALIDATION_KEY,
+                'scriptFile' => __DIR__ . '/index.php',
+                'scriptUrl' => '/index.php',
+            ],
+        );
     }
 
     /**

--- a/tests/WorkerDebugModuleTest.php
+++ b/tests/WorkerDebugModuleTest.php
@@ -123,10 +123,7 @@ final class WorkerDebugModuleTest extends TestCase
 
         MockerState::addCondition('yii2\extensions\debug', 'microtime', [true], $currentTime);
 
-        $headers = $this->createPartialMock(HeaderCollection::class, ['get', 'set']);
-
-        $headers->method('get')->with('REQUEST_TIME_FLOAT')->willReturn($startTime);
-
+        $headers = $this->createPartialMock(HeaderCollection::class, ['set']);
         $response = $this->createPartialMock(Response::class, ['getHeaders']);
 
         $response->method('getHeaders')->willReturn($headers);
@@ -388,7 +385,7 @@ final class WorkerDebugModuleTest extends TestCase
     /**
      * @throws InvalidConfigException if the configuration is invalid or incomplete.
      */
-    public function testSetDebugHeadersUsesYiiBeginTimeWhenRequestTimeFloatHeaderIsMissing(): void
+    public function testSetDebugHeadersUsesYiiBeginTimeWhenRequestTimeFloatServerParamIsMissing(): void
     {
         $headers = $this->createMock(HeaderCollection::class);
 

--- a/tests/WorkerDebugModuleTest.php
+++ b/tests/WorkerDebugModuleTest.php
@@ -36,7 +36,7 @@ use function dirname;
  * - Keeps response headers unchanged when log target is an array or string.
  * - Registers default module values and core panel classes.
  * - Skips header injection when sender is not a response.
- * - Uses `REQUEST_TIME_FLOAT` when available and `YII_BEGIN_TIME` when it is missing.
+ * - Uses REQUEST_TIME_FLOAT when available and YII_BEGIN_TIME when it is missing.
  *
  * @copyright Copyright (C) 2025 Terabytesoftw.
  * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
@@ -118,7 +118,7 @@ final class WorkerDebugModuleTest extends TestCase
      */
     public function testSetDebugHeadersCalculatesCorrectDurationInMilliseconds(): void
     {
-        $startTime = '1234567890.500';
+        $startTime = 1234567890.500;
         $currentTime = 1234567893.1234;
 
         MockerState::addCondition('yii2\extensions\debug', 'microtime', [true], $currentTime);
@@ -309,7 +309,7 @@ final class WorkerDebugModuleTest extends TestCase
      */
     public function testSetDebugHeadersUsesRequestTimeFloatWhenAvailable(): void
     {
-        $customStartTime = (string) (microtime(true) - 1);
+        $customStartTime = microtime(true) - 1;
 
         $headers = $this->createMock(HeaderCollection::class);
 

--- a/tests/WorkerProfilingPanelTest.php
+++ b/tests/WorkerProfilingPanelTest.php
@@ -30,7 +30,7 @@ final class WorkerProfilingPanelTest extends TestCase
      */
     public function testSaveReturnsCorrectDataStructureWithCustomStartTime(): void
     {
-        $customStartTime = (string) (microtime(true) - 2);
+        $customStartTime = microtime(true) - 2;
 
         $this->webApplication(
             [

--- a/tests/WorkerTimelinePanelTest.php
+++ b/tests/WorkerTimelinePanelTest.php
@@ -48,7 +48,7 @@ final class WorkerTimelinePanelTest extends TestCase
             (float) $customStartTime,
             $result['start'],
             0.005,
-            "'start' should match header-provided start time within 5ms tolerance.",
+            "'start' should match server-param-provided start time within 5ms tolerance.",
         );
         self::assertIsFloat(
             $result['end'] ?? null,

--- a/tests/WorkerTimelinePanelTest.php
+++ b/tests/WorkerTimelinePanelTest.php
@@ -26,7 +26,7 @@ final class WorkerTimelinePanelTest extends TestCase
      */
     public function testSaveReturnsCorrectDataStructureWithCustomStartTime(): void
     {
-        $customStartTime = (string) (microtime(true) - 2);
+        $customStartTime = microtime(true) - 2;
 
         $this->webApplication(
             [
@@ -45,7 +45,7 @@ final class WorkerTimelinePanelTest extends TestCase
             "'start' value should be a float representing the request start time.",
         );
         self::assertEqualsWithDelta(
-            (float) $customStartTime,
+            $customStartTime,
             $result['start'],
             0.005,
             "'start' should match server-param-provided start time within 5ms tolerance.",
@@ -56,7 +56,7 @@ final class WorkerTimelinePanelTest extends TestCase
         );
         self::assertGreaterThanOrEqual(
             2.0,
-            $result['end'] - (float) $customStartTime,
+            $result['end'] - $customStartTime,
             "'end' value should be approximately '2.0' seconds greater than the custom start time.",
         );
         self::assertGreaterThanOrEqual(


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |
